### PR TITLE
fix: Determine game path once, then write to and read from settings

### DIFF
--- a/B2BF.Common/Data/Settings.cs
+++ b/B2BF.Common/Data/Settings.cs
@@ -89,12 +89,12 @@ namespace B2BF.Common.Data
         {
             get
             {
-                return Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Phoenix Games");
+                return ReadValue("GamePath");
                 //return Path.Combine((IntPtr.Size == 8) ? Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86) : Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "Phoenix Network");
             }
             set
             {
-                WriteValue("GamePath", value.ToString());
+                WriteValue("GamePath", value);
             }
         }
         public static string BF2GamePath

--- a/B2BF.Launcher/Form1.cs
+++ b/B2BF.Launcher/Form1.cs
@@ -83,12 +83,25 @@ namespace B2BF.Launcher
 				label3.Text = "Username: " + AccountInfo.Username;
 				button2.Visible = false;
 
-				var existingInstall = RegistryHelper.GetBattlefield2Installation();
-				if (!string.IsNullOrEmpty(existingInstall) && !File.Exists(Path.Combine(Settings.BF2GamePath, "version.txt")))
+				if (string.IsNullOrEmpty(Settings.GamePath))
 				{
-					if (MessageBox.Show("An existing Battlefield 2 installation was detected, do you want to use that one?\n" + existingInstall, "Existing install detected", MessageBoxButtons.YesNo) == DialogResult.Yes)
+					var existingInstall = RegistryHelper.GetBattlefield2Installation();
+					var prompt = string.Join("\n\n",
+						"Detected an existing Battlefield 2 installation at:",
+						existingInstall,
+						"Do you want to use that instead of downloading a fresh copy?"
+					);
+					if (!string.IsNullOrEmpty(existingInstall) &&
+					    MessageBox.Show(prompt,
+						    "Existing installation detected",
+						    MessageBoxButtons.YesNo) ==
+					    DialogResult.Yes)
 					{
 						Settings.GamePath = existingInstall;
+					}
+					else
+					{
+						Settings.GamePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Phoenix Games");
 					}
 				}
 


### PR DESCRIPTION
Use game path from settings file, rather than always defaulting to `$pwd\Phoenix Games` in code.

Makes the behaviour a lot more consistent: `Settings.GamePath` will be set for every but the first launch, unless users delete the `settings.xml` or remove `GamePath` from it. In which case the launcher triggers the existing install detection again, defaults to the `$pwd\Phoenix Games` and writes the value back. If users manually modify `settings.xml`, that value will be used.