### PR TITLE
feat: Add cancel option to file validation prompt

### DIFF
--- a/B2BF.Launcher/Form1.cs
+++ b/B2BF.Launcher/Form1.cs
@@ -289,10 +289,17 @@ namespace B2BF.Launcher
 
             }
 
-            if (MessageBox.Show("Do you want to check ALL files? Checking all files will result in any modifications you made being overwritten permanently. Pressing 'No' will check only B2BF files", "Are you sure about that?", MessageBoxButtons.YesNo) == DialogResult.Yes)
+            var result = MessageBox.Show(
+                "Yes: Check all files, permanently overwrite any modifications.\nNo: Check only B2BF-specific files, leave all other files untouched.",
+                "Validate all game files?",
+                MessageBoxButtons.YesNoCancel
+            );
+            if (result == DialogResult.Cancel)
             {
-                _updater.OverWriteExisting = true;
+                return;
             }
+
+            _updater.OverWriteExisting = result == DialogResult.Yes;
 
             button1.Enabled = false;
             button3.Enabled = false;


### PR DESCRIPTION
Add a way of users to get out of the "Validate all game files?" prompt without choosing either option. If you don't fully understand what the options are doing, users would otherwise be forced to choose anyway or kill the launcher e.g. via task manager.