### PR TITLE
fix: Trigger server list update on game launch

### DIFF
--- a/B2BF.Common/Helpers/ServerListHelper.cs
+++ b/B2BF.Common/Helpers/ServerListHelper.cs
@@ -1,11 +1,6 @@
 ﻿using B2BF.Common.Account;
 using B2BF.Common.Models;
 using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Timers;
 
 namespace B2BF.Common.Helpers
@@ -29,7 +24,7 @@ namespace B2BF.Common.Helpers
 
         }
 
-        private static async void _timer_Elapsed(object? sender, ElapsedEventArgs e)
+        public static async Task UpdateServerList()
         {
             try
             {
@@ -41,8 +36,12 @@ namespace B2BF.Common.Helpers
             }
             catch (Exception ex)
             {
-
             }
+        }
+
+        private static async void _timer_Elapsed(object? sender, ElapsedEventArgs e)
+        {
+            await UpdateServerList();
         }
     }
 }

--- a/B2BF.Launcher/Form1.cs
+++ b/B2BF.Launcher/Form1.cs
@@ -177,6 +177,7 @@ namespace B2BF.Launcher
                 return;
             }
 
+            ServerListHelper.UpdateServerList();
             RegistryHelper.DisableBF2HubAutoPatching();
 
             OnNotify("Preflight check...");


### PR DESCRIPTION
30 second timer may not have triggered by the time the game is launched and requesting the server list, leading to an empty server list. Simple fix: manually trigger a server list update when the game is launched.